### PR TITLE
Add demo trading bot package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # trading-bot-binomo
-Bot automático para trading en Binomo usando visión artificial e inteligencia artificial.
+
+This repository contains a simple demonstration of an automated trading system for the Binomo demo platform. The new **binomo_bot** package provides a minimal GUI, trading logic, OCR stub, and WhatsApp notification simulator.
+
+## Running
+
+```bash
+python -m binomo_bot.main
+```
+
+This launches a Tkinter dashboard where trades are simulated with random results. The code is for educational purposes only and does **not** constitute financial advice.

--- a/binomo_bot/interfaz.py
+++ b/binomo_bot/interfaz.py
@@ -1,0 +1,81 @@
+"""tkinter based GUI for the trading bot."""
+
+import tkinter as tk
+from tkinter import ttk
+
+from .operaciones import Trader
+
+
+class TradingInterface(tk.Tk):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Binomo Demo Bot")
+        self.configure(bg="#222222")
+        self.geometry("800x500")
+
+        self.trader = Trader()
+        self.create_widgets()
+        self.update_balance()
+
+    def create_widgets(self) -> None:
+        control_frame = tk.Frame(self, bg="#222222")
+        control_frame.pack(side=tk.LEFT, fill=tk.Y, padx=10, pady=10)
+
+        tk.Label(control_frame, text="Initial Investment", fg="white", bg="#222222").pack(anchor="w")
+        self.initial_entry = tk.Entry(control_frame)
+        self.initial_entry.insert(0, "10000")
+        self.initial_entry.pack(anchor="w")
+
+        tk.Label(control_frame, text="Trade Time", fg="white", bg="#222222").pack(anchor="w", pady=(10, 0))
+        self.time_combo = ttk.Combobox(control_frame, values=["30s", "1min", "2min"], width=10)
+        self.time_combo.current(0)
+        self.time_combo.pack(anchor="w")
+
+        tk.Label(control_frame, text="Cycle Goal", fg="white", bg="#222222").pack(anchor="w", pady=(10, 0))
+        self.cycle_entry = tk.Entry(control_frame)
+        self.cycle_entry.insert(0, "200000")
+        self.cycle_entry.pack(anchor="w")
+
+        tk.Label(control_frame, text="Total Goal", fg="white", bg="#222222").pack(anchor="w", pady=(10, 0))
+        self.total_entry = tk.Entry(control_frame)
+        self.total_entry.insert(0, "1000000")
+        self.total_entry.pack(anchor="w")
+
+        self.start_button = tk.Button(control_frame, text="Start", command=self.start_trading)
+        self.start_button.pack(pady=(20, 0), fill="x")
+
+        self.stop_button = tk.Button(control_frame, text="Stop", command=self.stop_trading)
+        self.stop_button.pack(fill="x")
+
+        log_frame = tk.Frame(self, bg="#333333")
+        log_frame.pack(side=tk.RIGHT, fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        self.balance_var = tk.StringVar()
+        tk.Label(log_frame, textvariable=self.balance_var, fg="cyan", bg="#333333", font=("Arial", 14, "bold")).pack()
+
+        self.history_text = tk.Text(log_frame, state="disabled", bg="#111111", fg="white")
+        self.history_text.pack(fill=tk.BOTH, expand=True)
+
+    def update_balance(self) -> None:
+        self.balance_var.set(f"Balance: ${self.trader.balance:.2f}")
+        self.after(1000, self.update_balance)
+
+    def start_trading(self) -> None:
+        self.trader.balance = float(self.initial_entry.get())
+        self.trader.trade_time = self.time_combo.get()
+        self.trader.cycle_goal = float(self.cycle_entry.get())
+        self.trader.total_goal = float(self.total_entry.get())
+        self.after(1000, self.run_trade)
+
+    def run_trade(self) -> None:
+        self.trader.trade()
+        item = self.trader.history[-1]
+        self.history_text.configure(state="normal")
+        self.history_text.insert(tk.END, f"{item.action} {item.amount:.2f} -> {item.result}\n")
+        self.history_text.see(tk.END)
+        self.history_text.configure(state="disabled")
+        self.after(1000, self.run_trade)
+
+    def stop_trading(self) -> None:
+        self.after_cancel(self.run_trade)
+

--- a/binomo_bot/main.py
+++ b/binomo_bot/main.py
@@ -1,0 +1,12 @@
+"""Launcher script for the Binomo demo bot."""
+
+from .interfaz import TradingInterface
+
+
+def main() -> None:
+    app = TradingInterface()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/binomo_bot/operaciones.py
+++ b/binomo_bot/operaciones.py
@@ -1,0 +1,53 @@
+"""Trading logic for demo purposes."""
+
+from dataclasses import dataclass, field
+import random
+from typing import List
+
+from .whatsapp import send_message
+
+
+@dataclass
+class TradeHistoryItem:
+    action: str
+    amount: float
+    result: str
+
+
+@dataclass
+class Trader:
+    balance: float = 10000.0
+    cycle_goal: float = 200000.0
+    total_goal: float = 1000000.0
+    trade_time: str = "30s"
+    history: List[TradeHistoryItem] = field(default_factory=list)
+
+    def reset_cycle(self) -> None:
+        self.balance = 10000.0
+
+    def trade(self) -> None:
+        if self.balance <= 0:
+            self.reset_cycle()
+            return
+
+        prediction = random.choice(["HIGH", "LOW"])
+        amount = self.balance
+        # Simulate 80% chance of win for demo
+        win = random.random() < 0.6
+        if win:
+            profit = amount * 0.8
+            self.balance += profit
+            result = "won"
+        else:
+            self.balance -= amount
+            result = "lost"
+
+        self.history.append(TradeHistoryItem(action=prediction, amount=amount, result=result))
+
+        if self.balance >= self.cycle_goal:
+            send_message("Cycle goal reached. Resetting balance to $10,000")
+            self.reset_cycle()
+
+        if self.balance >= self.total_goal:
+            send_message("Total goal reached. Stopping bot.")
+            raise SystemExit

--- a/binomo_bot/visor.py
+++ b/binomo_bot/visor.py
@@ -1,0 +1,29 @@
+"""Simple screen capture and OCR module."""
+
+import numpy as np
+import pytesseract
+from PIL import ImageGrab
+import cv2
+
+
+# Configure path to tesseract if needed. Here we assume it's in PATH.
+
+BALANCE_REGION = (1085, 70, 1305, 120)  # (left, top, right, bottom)
+
+
+def capture_balance() -> float:
+    """Capture a region of the screen and attempt to read the balance."""
+    img = ImageGrab.grab(bbox=BALANCE_REGION)
+    frame = cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    _, thresh = cv2.threshold(gray, 150, 255, cv2.THRESH_BINARY)
+    text = pytesseract.image_to_string(thresh)
+    cleaned = text.strip().replace("\n", "")
+    # Extract digits
+    digits = ''.join(ch for ch in cleaned if ch.isdigit())
+    if not digits:
+        return 0.0
+    try:
+        return float(digits)
+    except ValueError:
+        return 0.0

--- a/binomo_bot/whatsapp.py
+++ b/binomo_bot/whatsapp.py
@@ -1,0 +1,9 @@
+"""Simulated WhatsApp notification module."""
+
+from datetime import datetime
+
+
+def send_message(text: str) -> None:
+    """Simulate sending a WhatsApp message by printing to stdout."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[WhatsApp {timestamp}] {text}")


### PR DESCRIPTION
## Summary
- add new `binomo_bot` package with GUI, demo trading logic, OCR stub and WhatsApp simulator
- update README with instructions for running the example

## Testing
- `python -m py_compile binomo_bot/*.py`
- `python -m binomo_bot.main` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_687724b4c1fc832dbc228d030a79d85b